### PR TITLE
Abzu/functional test fix

### DIFF
--- a/UKHO.FmEssFssMock.API/UKHO.FmEssFssMock.API/UKHO.FmEssFssMock.API.csproj
+++ b/UKHO.FmEssFssMock.API/UKHO.FmEssFssMock.API/UKHO.FmEssFssMock.API.csproj
@@ -11,7 +11,8 @@
     <NoWarn>1701;1702;8618;8602;8604;8600;8603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
   </ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.0" />
     <!--<PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />-->
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.0.2" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.22047.3" />
   </ItemGroup>
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Fulfilment/UKHO.PeriodicOutputService.Fulfilment.csproj
@@ -27,14 +27,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.0" />
-    <!--<PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />-->
+    <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.22047.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
'Unused' references removed earlier turn out to be used after all, suspect by Azure, and by reflection, hence confusing the IDE function to remove unused refs.