### PR TITLE
159261 - Exclude Permit for Empty Bespoke Exchange Set

### DIFF
--- a/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/FunctionalTests/BespokeExchangeSetService/DownloadBespokeExchangeSet.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/FunctionalTests/BespokeExchangeSetService/DownloadBespokeExchangeSet.cs
@@ -55,15 +55,19 @@ namespace UKHO.BESS.API.FunctionalTests.FunctionalTests.BespokeExchangeSetServic
 
         //PBI 147171: BESS BS - Handling of empty ES and Error.txt Scenarios
         [Test]
-        [TestCase("d0635e6c-81ae-4acb-9129-1a69f9ee58d2", "s57", "UPDATE")]
-        public async Task WhenIProcessSameConfigWithCorrectDetailsTwice_ThenEmptyExchangeSetShouldBeDownloaded(string batchId, string exchangeSetStandard, string type)
+        [TestCase("d0635e6c-81ae-4acb-9129-1a69f9ee58d2", "s57", "UPDATE", "NONE")]
+        [TestCase("d0635e6c-81ae-4acb-9129-1a69f9ee58d2", "s57", "UPDATE", "KEY_TEXT")]
+        public async Task WhenIProcessSameConfigWithCorrectDetailsTwice_ThenEmptyExchangeSetShouldBeDownloaded(string batchId, string exchangeSetStandard, string type, string keyFileType)
         {
-            Extensions.AddQueueMessage(type, exchangeSetStandard, testConfiguration.AzureWebJobsStorage, testConfiguration.bessStorageConfig.QueueName);
+            Extensions.AddQueueMessage(type, exchangeSetStandard, testConfiguration.AzureWebJobsStorage, testConfiguration.bessStorageConfig.QueueName, keyFileType);
             Extensions.WaitForDownloadExchangeSet();
-            Extensions.AddQueueMessage(type, exchangeSetStandard, testConfiguration.AzureWebJobsStorage, testConfiguration.bessStorageConfig.QueueName);
+            Extensions.AddQueueMessage(type, exchangeSetStandard, testConfiguration.AzureWebJobsStorage, testConfiguration.bessStorageConfig.QueueName, keyFileType);
             Extensions.WaitForDownloadExchangeSet();
             string downloadFolderPath = await EssEndpointHelper.CreateExchangeSetFile(batchId, false, null, true);
             FssBatchHelper.CheckFilesInEmptyBess(downloadFolderPath);
+            string? batchFolderPath = Path.GetDirectoryName(downloadFolderPath);
+            bool expectedResulted = FssBatchHelper.VerifyPermitFile(batchFolderPath, keyFileType);
+            expectedResulted.Should().Be(false);
         }
 
         [TearDown]

--- a/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/Helpers/Extensions.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/Helpers/Extensions.cs
@@ -74,11 +74,13 @@ namespace UKHO.BESS.API.FunctionalTests.Helpers
         /// <param name="exchangeSetStandard">Sets the value as s63 or s57 of the exchangeSetStandard as per config</param>
         /// <param name="webjobConnectionString">Sets the connectionString of the webJob</param>
         /// <param name="queueName">Sets the name of the table for queue</param>
-        public static void AddQueueMessage(string type, string? exchangeSetStandard, string? webjobConnectionString, string? queueName)
+        /// <param name="keyFileType">Sets the Permit file type for the queue. Default is set to NONE</param>
+        public static void AddQueueMessage(string type, string? exchangeSetStandard, string? webjobConnectionString, string? queueName, string? keyFileType = "NONE")
         {
             var queueMessage = JsonConvert.DeserializeObject<ConfigQueueMessage>(File.ReadAllText("./TestData/BSQueueMessage.txt"));
             queueMessage!.Type = type;
             queueMessage.ExchangeSetStandard = exchangeSetStandard!;
+            queueMessage.KeyFileType = keyFileType!;
             string jsonString = JsonConvert.SerializeObject(queueMessage);
 
             QueueClientOptions queueOptions = new() { MessageEncoding = QueueMessageEncoding.Base64 };

--- a/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/Helpers/FssBatchHelper.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/Helpers/FssBatchHelper.cs
@@ -327,7 +327,7 @@ namespace UKHO.BESS.API.FunctionalTests.Helpers
                 _ => keyFileType
             };
             string rootFolder = downloadFileUrl[..downloadFileUrl.LastIndexOf('/')];
-            string permitUri = rootFolder  + "/" + keyFileType;
+            string permitUri = rootFolder + "/" + keyFileType;
 
             var response = await FssApiClient.GetFileDownloadAsync(permitUri);
 
@@ -397,16 +397,20 @@ namespace UKHO.BESS.API.FunctionalTests.Helpers
         /// <returns></returns>
         public static bool VerifyPermitFile(string? downloadFolderPath, string? keyFileType)
         {
-            bool permitVerified = false;
-            if (keyFileType == "KEY_TEXT")
+            if (File.Exists(Path.Combine(downloadFolderPath!, testConfiguration.bessConfig.PermitTxtFile!)) || File.Exists(Path.Combine(downloadFolderPath!, testConfiguration.bessConfig.PermitXmlFile!)))
             {
-                permitVerified = CheckPermitTxtFile(downloadFolderPath);
+                bool permitVerified = false;
+                if (keyFileType == "KEY_TEXT")
+                {
+                    permitVerified = CheckPermitTxtFile(downloadFolderPath);
+                }
+                else if (keyFileType == "PERMIT_XML")
+                {
+                    permitVerified = CheckPermitXmlFile(downloadFolderPath);
+                }
+                return permitVerified;
             }
-            else if (keyFileType == "PERMIT_XML")
-            {
-                permitVerified = CheckPermitXmlFile(downloadFolderPath);
-            }
-            return permitVerified;
+            return false;
         }
     }
 }

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/Services/BuilderServiceTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/Services/BuilderServiceTests.cs
@@ -350,7 +350,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
               && call.GetArgument<LogLevel>(0) == LogLevel.Information
               && call.GetArgument<EventId>(1) == EventIds.PermitFileCreationCompleted.ToEventId()
               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Permit file creation completed for {KeyFileType} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();            
+              ).MustHaveHappenedOnceExactly();
         }
 
         [Test]
@@ -1074,6 +1074,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                            .Returns(new List<string> { @"D:\Test" });
             A.CallTo(() => fakeFileSystemHelper.GetFileInfo(A<string>.Ignored))
                 .Returns(fakeFileInfo);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(GetProductVersions);
             A.CallTo(() => fakeFssService.AddFileToBatch(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
                 .Returns(true);
             A.CallTo(() => fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
@@ -1097,7 +1098,6 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFssService.DownloadReadMeFileAsync(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored))
                .MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
@@ -1173,6 +1173,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                            .Returns(new List<string> { @"D:\Test" });
             A.CallTo(() => fakeFileSystemHelper.GetFileInfo(A<string>.Ignored))
                 .Returns(fakeFileInfo);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(GetProductVersions);
             A.CallTo(() => fakeFssService.AddFileToBatch(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
                 .Returns(true);
             A.CallTo(() => fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
@@ -1196,7 +1197,6 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFssService.DownloadReadMeFileAsync(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
@@ -1267,6 +1267,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                            .Returns(new List<string> { @"D:\Test" });
             A.CallTo(() => fakeFileSystemHelper.GetFileInfo(A<string>.Ignored))
                 .Returns(fakeFileInfo);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(GetProductVersions);
             A.CallTo(() => fakeFssService.AddFileToBatch(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
                 .Returns(true);
             A.CallTo(() => fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
@@ -1290,7 +1291,6 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.CreateEmptyFileContent(A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
@@ -1349,6 +1349,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                            .Returns(new List<string> { @"D:\Test" });
             A.CallTo(() => fakeFileSystemHelper.GetFileInfo(A<string>.Ignored))
                 .Returns(fakeFileInfo);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(GetProductVersions);
             A.CallTo(() => fakeFssService.AddFileToBatch(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
                 .Returns(true);
             A.CallTo(() => fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
@@ -1372,7 +1373,6 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeFileSystemHelper.CreateEmptyFileContent(A<string>.Ignored))
                .MustHaveHappenedOnceExactly();
-            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
             A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
@@ -1519,6 +1519,8 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .MustHaveHappenedOnceExactly();
             A.CallTo(() => fakeAzureTableStorageHelper.SaveBessProductVersionDetailsAsync((A<List<ProductVersion>>.Ignored), A<string>.Ignored, A<string>.Ignored))
                 .MustNotHaveHappened();
+            A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
+              .MustNotHaveHappened();
 
             A.CallTo(fakeLogger).Where(call =>
             call.Method.Name == "Log"
@@ -1554,6 +1556,27 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 && call.GetArgument<EventId>(1) == EventIds.EmptyBatchResponse.ToEventId()
                 && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Latest edition/update details not found. | DateTime: {DateTime} | _X-Correlation-ID : {CorrelationId}"
             ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsNoUpdateFoundForProducts.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Skipped Product Key Service request as no updates are found for requested product(s) | BESS Type : {type} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+            ).MustNotHaveHappened();
+
+            A.CallTo(fakeLogger).Where(call =>
+              call.Method.Name == "Log"
+              && call.GetArgument<LogLevel>(0) == LogLevel.Information
+              && call.GetArgument<EventId>(1) == EventIds.PermitFileCreationStarted.ToEventId()
+              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Permit file creation started for {KeyFileType} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+              ).MustNotHaveHappened();
+
+            A.CallTo(fakeLogger).Where(call =>
+              call.Method.Name == "Log"
+              && call.GetArgument<LogLevel>(0) == LogLevel.Information
+              && call.GetArgument<EventId>(1) == EventIds.PermitFileCreationCompleted.ToEventId()
+              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Permit file creation completed for {KeyFileType} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+              ).MustNotHaveHappened();
         }
 
         [Test]
@@ -1812,6 +1835,7 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
                 .Returns(new List<string> { "Block_00001" });
             A.CallTo(() => fakeFssService.WriteBlockFile(A<string>.Ignored, A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<string>.Ignored))
                 .Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(GetProductVersions);
             A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
              .Returns(GetProductKeyServiceResponse());
             var result = await builderService.CreateBespokeExchangeSetAsync(GetConfigQueueMessage(BessType.BASE, exchangeSetStandard, ReadMeSearchFilter.AVCS.ToString(), KeyFileType.KEY_TEXT));
@@ -1861,6 +1885,124 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
               && call.GetArgument<EventId>(1) == EventIds.PermitFileCreationCompleted.ToEventId()
               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Permit file creation completed for {KeyFileType} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
               ).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        [TestCase(ExchangeSetStandard.S63)]
+        [TestCase(ExchangeSetStandard.S57)]
+        public async Task WhenTypeIsBase_AndNoLatestProductVersionFoundThenEmptyBespokeExchangeSetIsCreatedWithNoPermitFile(ExchangeSetStandard exchangeSetStandard)
+        {
+            A.CallTo(() => fakeEssService.PostProductIdentifiersData(A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
+                .Returns(GetValidExchangeSetGetBatchResponse());
+            A.CallTo(() => fakeFssService.CheckIfBatchCommitted(A<string>.Ignored, A<RequestType>.Ignored, A<string>.Ignored))
+              .Returns(FssBatchStatus.Committed);
+            A.CallTo(() => fakeFssService.GetBatchDetails(A<string>.Ignored, A<string>.Ignored))
+              .Returns(GetValidBatchResponseModel());
+            A.CallTo(() => fakeFssService.CreateBatch(A<Batch>.Ignored, A<ConfigQueueMessage>.Ignored, A<string>.Ignored))
+               .Returns(Guid.NewGuid().ToString());
+            A.CallTo(() => fakeFileSystemHelper.GetFiles(A<string>.Ignored, A<string>.Ignored, A<SearchOption>.Ignored))
+                           .Returns(new List<string> { @"D:\Test" });
+            A.CallTo(() => fakeFileSystemHelper.GetFileInfo(A<string>.Ignored))
+                .Returns(fakeFileInfo);
+            A.CallTo(() => fakeFssService.AddFileToBatch(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
+                .Returns(true);
+            A.CallTo(() => fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
+             .Returns(true);
+            A.CallTo(() => fakeFssService.UploadBlocks(A<string>.Ignored, A<IFileInfo>.Ignored, A<string>.Ignored))
+                .Returns(new List<string> { "Block_00001" });
+            A.CallTo(() => fakeFssService.WriteBlockFile(A<string>.Ignored, A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<string>.Ignored))
+                .Returns(true);
+            A.CallTo(() => fakeFileSystemHelper.GetProductVersionsFromDirectory(A<string>.Ignored, A<string>.Ignored)).Returns(new List<ProductVersion>() { });
+
+            var result = await builderService.CreateBespokeExchangeSetAsync(GetConfigQueueMessage(BessType.BASE, exchangeSetStandard, ReadMeSearchFilter.AVCS.ToString(), KeyFileType.PERMIT_XML));
+
+            result.Should().Be(true);
+
+            A.CallTo(() => fakeFileSystemHelper.CreateDirectory(A<string>.Ignored))
+               .MustHaveHappenedOnceOrMore();
+            A.CallTo(() => fakeFssService.DownloadFileAsync(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<string>.Ignored))
+              .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileInfo.MoveTo(A<string>.Ignored))
+               .MustHaveHappenedOnceOrMore();
+            A.CallTo(() => fakeFileSystemHelper.ExtractZipFile(A<string>.Ignored, A<string>.Ignored, true))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.ReadFileText(A<string>.Ignored))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.DeleteFile(A<string>.Ignored))
+               .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.DeleteFolder(A<string>.Ignored))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFileSystemHelper.CreateZipFile(A<string>.Ignored, A<string>.Ignored, A<bool>.Ignored))
+                .MustHaveHappenedOnceExactly();
+            A.CallTo(() => fakeFssService.WriteBlockFile(A<string>.Ignored, A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<string>.Ignored))
+                .MustHaveHappenedOnceOrMore();
+            A.CallTo(() => fakePksService.PostProductKeyData(A<List<ProductKeyServiceRequest>>.Ignored, A<string>.Ignored))
+              .MustNotHaveHappened();
+            A.CallTo(() => fakeFileSystemHelper.CreateXmlFromObject(A<PksXml>.Ignored, A<string>.Ignored, A<string>.Ignored))
+                .MustNotHaveHappened();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.ProductsFetchedFromESS.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "No of Products requested to ESS : {productCount}, No of valid Cells count received from ESS: {cellCount} and Invalid cells count: {invalidCellCount} | DateTime: {DateTime} | _X-Correlation-ID:{CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+              call.Method.Name == "Log"
+              && call.GetArgument<LogLevel>(0) == LogLevel.Information
+              && call.GetArgument<EventId>(1) == EventIds.ZipFileRenamed.ToEventId()
+              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Zip file {fileName} renamed to file {newFileName} at {DateTime} | _X-Correlation-ID:{CorrelationId}"
+              ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.ExtractZipFileStarted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.ExtractZipFileCompleted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.ZipFileCreationStarted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.ZipFileCreationCompleted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.BessBatchCreationStarted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "BESS batch creation started at {DateTime} | _X-Correlation-ID: {CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.BessBatchCreationCompleted.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "BESS batch: {bessBatchId} is created and added to FSS with status: {isCommitted} at {DateTime} | _X-Correlation-ID: {CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
+
+            A.CallTo(fakeLogger).Where(call =>
+            call.Method.Name == "Log"
+            && call.GetArgument<LogLevel>(0) == LogLevel.Information
+            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsNoUpdateFoundForProducts.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Skipped Product Key Service request as no updates are found for requested product(s) | BESS Type : {type} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+            ).MustHaveHappenedOnceExactly();
         }
 
         #region PrivateMethods

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/Services/BuilderServiceTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/Services/BuilderServiceTests.cs
@@ -1560,8 +1560,8 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
             A.CallTo(fakeLogger).Where(call =>
             call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsNoUpdateFoundForProducts.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Skipped Product Key Service request as no updates are found for requested product(s) | BESS Type : {type} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsEmptyExchangeSetFoundForProducts.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Product Key Service request was skipped because an Empty Exchange Set was found for the requested product(s) | {DateTime} | _X-Correlation-ID : {CorrelationId}"
             ).MustNotHaveHappened();
 
             A.CallTo(fakeLogger).Where(call =>
@@ -2000,8 +2000,8 @@ namespace UKHO.BESS.BuilderService.UnitTests.Services
             A.CallTo(fakeLogger).Where(call =>
             call.Method.Name == "Log"
             && call.GetArgument<LogLevel>(0) == LogLevel.Information
-            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsNoUpdateFoundForProducts.ToEventId()
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Skipped Product Key Service request as no updates are found for requested product(s) | BESS Type : {type} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
+            && call.GetArgument<EventId>(1) == EventIds.SkipPksAsEmptyExchangeSetFoundForProducts.ToEventId()
+            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2)!.ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Product Key Service request was skipped because an Empty Exchange Set was found for the requested product(s) | {DateTime} | _X-Correlation-ID : {CorrelationId}"
             ).MustHaveHappenedOnceExactly();
         }
 

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/Services/BuilderService.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/Services/BuilderService.cs
@@ -82,7 +82,14 @@ namespace UKHO.BESS.BuilderService.Services
 
             var latestProductVersions = GetTheLatestUpdateNumber(essFileDownloadPath, configQueueMessage.EncCellNames.ToArray(), bessZipFileName);
 
-            await RequestCellKeysFromPksAsync(configQueueMessage, essFileDownloadPath, latestProductVersions);
+            if (latestProductVersions.ProductVersions.Any())
+            {
+                await RequestCellKeysFromPksAsync(configQueueMessage, essFileDownloadPath, latestProductVersions);
+            }
+            else if (!string.Equals(configQueueMessage.KeyFileType, KeyFileType.NONE.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation(EventIds.SkipPksAsNoUpdateFoundForProducts.ToEventId(), "Skipped Product Key Service request as no updates are found for requested product(s) | BESS Type : {type} | {DateTime} | _X-Correlation-ID : {CorrelationId}", configQueueMessage.Type, DateTime.UtcNow, configQueueMessage.CorrelationId);
+            }
 
             CreateZipFile(essFiles, essFileDownloadPath, configQueueMessage.CorrelationId);
 

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Logging/EventIds.cs
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Logging/EventIds.cs
@@ -823,7 +823,12 @@ namespace UKHO.PeriodicOutputService.Common.Logging
         /// <summary>
         /// 809163 - Bess file renamed
         /// </summary>
-        ZipFileRenamed = 809163
+        ZipFileRenamed = 809163,
+
+        /// <summary>
+        /// 809164 - Skipping product key service request as no update found for given products (empty bespoke exchange set)
+        /// </summary>
+        SkipPksAsNoUpdateFoundForProducts = 809164
     }
 
     public static class EventIdExtensions

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Logging/EventIds.cs
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Logging/EventIds.cs
@@ -828,7 +828,7 @@ namespace UKHO.PeriodicOutputService.Common.Logging
         /// <summary>
         /// 809164 - Skipping product key service request as no update found for given products (empty bespoke exchange set)
         /// </summary>
-        SkipPksAsNoUpdateFoundForProducts = 809164
+        SkipPksAsEmptyExchangeSetFoundForProducts = 809164
     }
 
     public static class EventIdExtensions


### PR DESCRIPTION
This PR consists changes from [PBI - 159261](https://dev.azure.com/ukhydro/Exchange%20Set%20Service/_workitems/edit/159261)

- Added code changes to skip permit generation for empty BES
- Uplifted UTs
- Uplifted FTs