### PR TITLE
Set year correctly in Serial AIO file

### DIFF
--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
@@ -96,7 +96,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
 
             A.CallTo(() => _fakeEssService.PostProductIdentifiersData(A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
               .Returns(GetValidExchangeSetGetBatchResponse());
-            
+
             A.CallTo(() => _fakeEssService.GetProductDataProductVersions(
                     A<ProductVersionsRequest>.That.Matches(r =>
                         r.ProductVersions.Count == 1 && r.ProductVersions[0].ProductName == _aioProductName &&
@@ -646,7 +646,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             ]
         };
 
-        private static List<ProductVersionEntities>  GetProductVersionEntities() => new()
+        private static List<ProductVersionEntities> GetProductVersionEntities() => new()
         {
             new ProductVersionEntities
             {

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
@@ -30,6 +30,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
         private IAzureTableStorageHelper _fakeAzureTableStorageHelper;
         private IOptions<FssApiConfiguration> _fakeFssApiConfiguration;
         private static readonly string _aioProductName = "GB800001";
+        private FormattedWeekNumber _formattedWeekNumber;
 
         [SetUp]
         public void Setup()
@@ -45,6 +46,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             _fakeconfiguration["IsFTRunning"] = "false";
             _fakeconfiguration["AioCells"] = _aioProductName;
             _fakeconfiguration["WeeksToIncrement"] = "1";
+            _formattedWeekNumber = CommonHelper.GetCurrentWeekNumber(DateTime.UtcNow, 1);
 
             _fakeFssApiConfiguration = Options.Create(new FssApiConfiguration()
             {
@@ -84,8 +86,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             exception = Assert.Throws<ArgumentNullException>(
                 () => new FulfilmentDataService(_fakefileSystemHelper, _fakeEssService, _fakeFssService, _fakeLogger, _fakeconfiguration, _fakeAzureTableStorageHelper, null));
             Assert.That(exception.ParamName, Is.EqualTo("fssApiConfig"));
-
-
         }
 
         [Test]
@@ -131,6 +131,9 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             A.CallTo(() => _fakeFssService.CommitBatch(A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<Batch>.Ignored, A<string>.Ignored))
               .Returns(true);
 
+            A.CallTo(() => _fakefileSystemHelper.FileExists(A<string>.Ignored))
+                .Returns(true);
+
             var result = await _fulfilmentDataService.CreateAioExchangeSetsAsync();
 
             Assert.That(result, Is.True);
@@ -156,81 +159,28 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             A.CallTo(() => _fakeFssService.WriteBlockFile(A<string>.Ignored, A<string>.Ignored, A<IEnumerable<string>>.Ignored, A<string>.Ignored))
                 .MustHaveHappenedOnceOrMore();
 
-            #region Log checks
+            A.CallTo(() => _fakefileSystemHelper.FileExists(A<string>.Ignored))
+                .MustHaveHappened(2, Times.Exactly);
 
-            A.CallTo(_fakeLogger).Where(call =>
-                  call.Method.Name == "Log"
-                  && call.GetArgument<LogLevel>(0) == LogLevel.Information
-                  && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Getting latest product version details started | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-                  ).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _fakefileSystemHelper.CreateFileContent(A<string>.Ignored, A<string>.Ignored))
+                .MustHaveHappened(2, Times.Exactly);
 
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Information
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Getting latest product version details completed | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-             call.Method.Name == "Log"
-             && call.GetArgument<LogLevel>(0) == LogLevel.Information
-             && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creation of update exchange set for Productversions - {Productversions} started | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-             ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Information
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Update exchange set created successfully | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-                call.Method.Name == "Log"
-                && call.GetArgument<LogLevel>(0) == LogLevel.Information
-                && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creation of AIO base exchange set started | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-                ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-                call.Method.Name == "Log"
-                && call.GetArgument<LogLevel>(0) == LogLevel.Information
-                && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creation of AIO base exchange set completed | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-                ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-                call.Method.Name == "Log"
-                && call.GetArgument<LogLevel>(0) == LogLevel.Information
-                && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Batch for AIO base CD created by ESS successfully with BatchID - {BatchID} | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-                ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-                call.Method.Name == "Log"
-                && call.GetArgument<LogLevel>(0) == LogLevel.Information
-                && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-                ).MustHaveHappened(2, Times.Exactly);
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating ISO and Sha1 file of {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Information
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Logging product version started | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Information
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Logging product version completed | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Information
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-              ).MustHaveHappened(2, Times.Exactly);
-
-            #endregion Log checks
+            CheckLog(EventIds.GetLatestProductVersionDetailsStarted, "Getting latest product version details started | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.GetLatestProductVersionDetailsCompleted, "Getting latest product version details completed | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.AioUpdateExchangeSetCreationStarted, "Creation of update exchange set for Productversions - {Productversions} started | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.AioUpdateExchangeSetCreationCompleted, "Update exchange set created successfully | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.AioBaseExchangeSetCreationStarted, "Creation of AIO base exchange set started | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.AioBaseExchangeSetCreationCompleted, "Creation of AIO base exchange set completed | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.BatchCreatedInESS, "Batch for AIO base CD created by ESS successfully with BatchID - {BatchID} | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.ExtractZipFileStarted, "Extracting zip file {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 2);
+            CheckLog(EventIds.ExtractZipFileCompleted, "Extracting zip file {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 2);
+            CheckLog(EventIds.CreateIsoAndSha1Started, "Creating ISO and Sha1 file of {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}");
+            CheckLog(EventIds.CreateIsoAndSha1Completed, "Creating ISO and Sha1 file of {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}");
+            CheckLog(EventIds.LoggingProductVersionsStarted, "Logging product version started | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.LoggingProductVersionsCompleted, "Logging product version completed | {DateTime} | _X-Correlation-ID : {CorrelationId}");
+            CheckLog(EventIds.ZipFileCreationStarted, "Creating zip file of directory {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 2);
+            CheckLog(EventIds.ZipFileCreationCompleted, "Creating zip file of directory {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 2);
+            CheckLog(EventIds.SerialAioUpdated, "SERIAL.AIO file at {serialFilePath} updated with year {year} and week number {weekNumber} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 2, additionalParmsToCheck: [new("year", _formattedWeekNumber.YearShort), new("weekNumber", _formattedWeekNumber.Week)]);
         }
 
         [Test]
@@ -661,5 +611,38 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
                 UpdateNumber = 0
             }
         };
+
+        private void CheckLog(EventIds eventIds, string originalFormat, LogLevel logLevel = LogLevel.Information, int numberOfTimes = 1, List<KeyValuePair<string, object>> additionalParmsToCheck = null)
+        {
+            var eventId = eventIds.ToEventId();
+            A.CallTo(_fakeLogger).Where(call =>
+                call.Method.Name == "Log"
+                && call.GetArgument<LogLevel>(0) == logLevel
+                && call.GetArgument<EventId>(1) == eventId
+                && CheckLogParameters(call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2), originalFormat, additionalParmsToCheck)
+                ).MustHaveHappened(numberOfTimes, Times.Exactly);
+        }
+
+        private static bool CheckLogParameters(IEnumerable<KeyValuePair<string, object>> keyValuePairs, string originalFormat, List<KeyValuePair<string, object>> additionalParmsToCheck)
+        {
+            var dictionary = keyValuePairs.ToDictionary(c => c.Key, c => c.Value, StringComparer.OrdinalIgnoreCase);
+
+            if (additionalParmsToCheck is null)
+            {
+                return dictionary["{OriginalFormat}"].ToString() == originalFormat;
+            }
+            else
+            {
+                var result = dictionary["{OriginalFormat}"].ToString() == originalFormat;
+
+                foreach (var additionalParm in additionalParmsToCheck)
+                {
+                    var keyFound = dictionary.TryGetValue(additionalParm.Key, out var value);
+                    result = result && keyFound && value.ToString() == additionalParm.Value.ToString();
+                }
+
+                return result;
+            }
+        }
     }
 }

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/Services/FulfilmentDataServiceTests.cs
@@ -187,19 +187,18 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
         public void Does_CreateAioExchangeSets_Throws_Error_When_Batch_Is_Not_Committed()
         {
             A.CallTo(() => _fakeEssService.PostProductIdentifiersData(A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
-            .Returns(GetValidExchangeSetGetBatchResponse());
+                .Returns(GetValidExchangeSetGetBatchResponse());
+
+            A.CallTo(() => _fakeEssService.GetProductDataProductVersions(A<ProductVersionsRequest>.Ignored, A<string>.Ignored, A<string>.Ignored))
+                .Returns(GetValidExchangeSetGetBatchResponse());
 
             A.CallTo(() => _fakeFssService.CheckIfBatchCommitted(A<string>.Ignored, A<RequestType>.Ignored, A<string>.Ignored))
-              .Returns(FssBatchStatus.CommitInProgress);
+                .Returns(FssBatchStatus.CommitInProgress);
 
             Assert.ThrowsAsync<FulfilmentException>(
                  () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Batch is not committed within given polling cut off time | {DateTime} | Batch Status : {BatchStatus} | _X-Correlation-ID : {CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.FssPollingCutOffTimeout, "Batch is not committed within given polling cut off time | {DateTime} | Batch Status : {BatchStatus} | _X-Correlation-ID : {CorrelationId}", LogLevel.Error, timesOption: Times.OrMore);
         }
 
         [Test]
@@ -222,23 +221,9 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             A.CallTo(() => _fakeFssService.DownloadFileAsync(A<string>.Ignored, A<string>.Ignored, A<long>.Ignored, A<string>.Ignored, A<string>.Ignored))
               .MustHaveHappenedOnceExactly();
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustNotHaveHappened();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Extracting zip file {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.ExtractZipFileStarted, "Extracting zip file {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}");
+            CheckLog(EventIds.ExtractZipFileCompleted, "Extracting zip file {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 0);
+            CheckLog(EventIds.ExtractZipFileFailed, "Extracting zip file {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}", LogLevel.Error);
         }
 
         [Test]
@@ -264,23 +249,9 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             A.CallTo(() => _fakefileSystemHelper.ExtractZipFile(A<string>.Ignored, A<string>.Ignored, A<bool>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating ISO and Sha1 file of {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating ISO and Sha1 file of {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustNotHaveHappened();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating ISO and Sha1 file of {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.CreateIsoAndSha1Started, "Creating ISO and Sha1 file of {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}");
+            CheckLog(EventIds.CreateIsoAndSha1Completed, "Creating ISO and Sha1 file of {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 0);
+            CheckLog(EventIds.CreateIsoAndSha1Failed, "Creating ISO and Sha1 file of {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}", LogLevel.Error);
         }
 
         [Test]
@@ -291,11 +262,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<FulfilmentException>(
                 () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "AIO cells are empty in configuration | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.AioCellsConfigurationMissing, "AIO cells are empty in configuration | {DateTime} | _X-Correlation-ID : {CorrelationId}", LogLevel.Error);
 
             A.CallTo(() => _fakeEssService.PostProductIdentifiersData(A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored))
              .MustNotHaveHappened();
@@ -319,11 +286,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<FulfilmentException>(
                 () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-            call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Error
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Either no files found or error file found in batch with BatchID - {BatchID} | {DateTime} | _X-Correlation-ID:{CorrelationId}"
-            ).MustHaveHappenedOnceOrMore();
+            CheckLog(EventIds.ErrorFileFoundInBatch, "Either no files found or error file found in batch with BatchID - {BatchID} | {DateTime} | _X-Correlation-ID:{CorrelationId}", LogLevel.Error, timesOption: Times.OrMore);
         }
 
         [Test]
@@ -344,11 +307,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<FulfilmentException>(
                 () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-            call.Method.Name == "Log"
-            && call.GetArgument<LogLevel>(0) == LogLevel.Error
-            && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "The configuration of the AIO cell is not synchronized with the ESS. V01X01 file found in AIO batch - {BatchID} | {DateTime} | _X-Correlation-ID:{CorrelationId}"
-            ).MustHaveHappenedOnceOrMore();
+            CheckLog(EventIds.V01X01FileFoundInAIOBatch, "The configuration of the AIO cell is not synchronized with the ESS. V01X01 file found in AIO batch - {BatchID} | {DateTime} | _X-Correlation-ID:{CorrelationId}", LogLevel.Error, timesOption: Times.OrMore);
         }
 
         [Test]
@@ -374,11 +333,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<Exception>(
                () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-              call.Method.Name == "Log"
-              && call.GetArgument<LogLevel>(0) == LogLevel.Error
-              && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Logging product version failed | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-              ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.LoggingProductVersionsFailed, "Logging product version failed | {DateTime} | _X-Correlation-ID : {CorrelationId}", LogLevel.Error);
         }
 
         [Test]
@@ -404,23 +359,9 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             A.CallTo(() => _fakefileSystemHelper.ExtractZipFile(A<string>.Ignored, A<string>.Ignored, A<bool>.Ignored))
                 .MustHaveHappenedOnceExactly();
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Information
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}"
-               ).MustNotHaveHappened();
-
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Creating zip file of directory {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.ZipFileCreationStarted, "Creating zip file of directory {fileName} started at {DateTime} | _X-Correlation-ID:{CorrelationId}");
+            CheckLog(EventIds.ZipFileCreationCompleted, "Creating zip file of directory {fileName} completed at {DateTime} | _X-Correlation-ID:{CorrelationId}", numberOfTimes: 0);
+            CheckLog(EventIds.ZipFileCreationFailed, "Creating zip file of directory {fileName} failed at {DateTime} | {ErrorMessage} | _X-Correlation-ID:{CorrelationId}", LogLevel.Error);
         }
 
         [Test]
@@ -435,11 +376,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<FulfilmentException>(
               () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "Due to the empty exchange set, ESS validation failed while producing an update | {DateTime} | _X-Correlation-ID : {CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.EssValidationFailed, "Due to the empty exchange set, ESS validation failed while producing an update | {DateTime} | _X-Correlation-ID : {CorrelationId}", LogLevel.Error);
         }
 
         [Test]
@@ -454,11 +391,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             Assert.ThrowsAsync<FulfilmentException>(
              () => _fulfilmentDataService.CreateAioExchangeSetsAsync());
 
-            A.CallTo(_fakeLogger).Where(call =>
-               call.Method.Name == "Log"
-               && call.GetArgument<LogLevel>(0) == LogLevel.Error
-               && call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2).ToDictionary(c => c.Key, c => c.Value)["{OriginalFormat}"].ToString() == "ESS validation failed for {Count} products [{Products}] while creating update exchange set {DateTime} | _X-Correlation-ID : {CorrelationId}"
-               ).MustHaveHappenedOnceExactly();
+            CheckLog(EventIds.EssValidationFailed, "ESS validation failed for {Count} products [{Products}] while creating update exchange set {DateTime} | _X-Correlation-ID : {CorrelationId}", LogLevel.Error);
         }
 
         private static ExchangeSetResponseModel GetValidExchangeSetGetBatchResponse() => new()
@@ -612,7 +545,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
             }
         };
 
-        private void CheckLog(EventIds eventIds, string originalFormat, LogLevel logLevel = LogLevel.Information, int numberOfTimes = 1, List<KeyValuePair<string, object>> additionalParmsToCheck = null)
+        private void CheckLog(EventIds eventIds, string originalFormat, LogLevel logLevel = LogLevel.Information, int numberOfTimes = 1, List<KeyValuePair<string, object>>? additionalParmsToCheck = null, Times? timesOption = null)
         {
             var eventId = eventIds.ToEventId();
             A.CallTo(_fakeLogger).Where(call =>
@@ -620,29 +553,25 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.Services
                 && call.GetArgument<LogLevel>(0) == logLevel
                 && call.GetArgument<EventId>(1) == eventId
                 && CheckLogParameters(call.GetArgument<IEnumerable<KeyValuePair<string, object>>>(2), originalFormat, additionalParmsToCheck)
-                ).MustHaveHappened(numberOfTimes, Times.Exactly);
+                ).MustHaveHappened(numberOfTimes, timesOption ?? Times.Exactly);
         }
 
-        private static bool CheckLogParameters(IEnumerable<KeyValuePair<string, object>> keyValuePairs, string originalFormat, List<KeyValuePair<string, object>> additionalParmsToCheck)
+        private static bool CheckLogParameters(IEnumerable<KeyValuePair<string, object>> keyValuePairs, string originalFormat, List<KeyValuePair<string, object>>? additionalParmsToCheck)
         {
             var dictionary = keyValuePairs.ToDictionary(c => c.Key, c => c.Value, StringComparer.OrdinalIgnoreCase);
+            var keyFound = dictionary.TryGetValue("{OriginalFormat}", out var value);
+            var result = keyFound && value.ToString() == originalFormat;
 
-            if (additionalParmsToCheck is null)
+            if (additionalParmsToCheck is not null)
             {
-                return dictionary["{OriginalFormat}"].ToString() == originalFormat;
-            }
-            else
-            {
-                var result = dictionary["{OriginalFormat}"].ToString() == originalFormat;
-
                 foreach (var additionalParm in additionalParmsToCheck)
                 {
-                    var keyFound = dictionary.TryGetValue(additionalParm.Key, out var value);
+                    keyFound = dictionary.TryGetValue(additionalParm.Key, out value);
                     result = result && keyFound && value.ToString() == additionalParm.Value.ToString();
                 }
-
-                return result;
             }
+
+            return result;
         }
     }
 }

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Services/FulfilmentDataService.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Services/FulfilmentDataService.cs
@@ -463,13 +463,13 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.Services
 
                 try
                 {
-                   if (File.Exists(serialFilePath))
+                   if (_fileSystemHelper.FileExists(serialFilePath))
                    {
                        var serialFileContent = $"GBWK{weekNumber.Week}-{DateTime.UtcNow:yy}   {DateTime.UtcNow.Year:D4}{DateTime.UtcNow.Month:D2}{DateTime.UtcNow.Day:D2}{cdType,-10}{2:D2}.00\x0b\x0d\x0a";
 
                        _fileSystemHelper.CreateFileContent(serialFilePath, serialFileContent);
 
-                       _logger.LogInformation(EventIds.SerialAioUpdated.ToEventId(), "SERIAL.AIO file at {serialFilePath} updated with week number {weekNumber} | _X-Correlation-ID:{CorrelationId}", serialFilePath, weekNumber.Week, CommonHelper.CorrelationID);
+                       _logger.LogInformation(EventIds.SerialAioUpdated.ToEventId(), "SERIAL.AIO file at {serialFilePath} updated with year {year} and week number {weekNumber} | _X-Correlation-ID:{CorrelationId}", serialFilePath, DateTime.UtcNow.ToString("yy"), weekNumber.Week, CommonHelper.CorrelationID);
                    }   
                     
                 }

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Services/FulfilmentDataService.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Services/FulfilmentDataService.cs
@@ -456,22 +456,21 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment.Services
         private void UpdateSerialAioFile(List<FssBatchFile> fileDetails, string downloadPath, string cdType, FormattedWeekNumber weekNumber)
         {
             var serialFileName = _fssApiConfig.Value.SerialFileName;
-           
+
             Parallel.ForEach(fileDetails, file =>
             {
                 var serialFilePath = Path.Combine(downloadPath, Path.GetFileNameWithoutExtension(file.FileName), serialFileName);
 
                 try
                 {
-                   if (_fileSystemHelper.FileExists(serialFilePath))
-                   {
-                       var serialFileContent = $"GBWK{weekNumber.Week}-{DateTime.UtcNow:yy}   {DateTime.UtcNow.Year:D4}{DateTime.UtcNow.Month:D2}{DateTime.UtcNow.Day:D2}{cdType,-10}{2:D2}.00\x0b\x0d\x0a";
+                    if (_fileSystemHelper.FileExists(serialFilePath))
+                    {
+                        var serialFileContent = $"GBWK{weekNumber.Week}-{weekNumber.YearShort}   {DateTime.UtcNow.Year:D4}{DateTime.UtcNow.Month:D2}{DateTime.UtcNow.Day:D2}{cdType,-10}{2:D2}.00\x0b\x0d\x0a";
 
-                       _fileSystemHelper.CreateFileContent(serialFilePath, serialFileContent);
+                        _fileSystemHelper.CreateFileContent(serialFilePath, serialFileContent);
 
-                       _logger.LogInformation(EventIds.SerialAioUpdated.ToEventId(), "SERIAL.AIO file at {serialFilePath} updated with year {year} and week number {weekNumber} | _X-Correlation-ID:{CorrelationId}", serialFilePath, DateTime.UtcNow.ToString("yy"), weekNumber.Week, CommonHelper.CorrelationID);
-                   }   
-                    
+                        _logger.LogInformation(EventIds.SerialAioUpdated.ToEventId(), "SERIAL.AIO file at {serialFilePath} updated with year {year} and week number {weekNumber} | _X-Correlation-ID:{CorrelationId}", serialFilePath, weekNumber.YearShort, weekNumber.Week, CommonHelper.CorrelationID);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common.UnitTests/Helpers/FileSystemHelperTests.cs
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common.UnitTests/Helpers/FileSystemHelperTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.IO.Abstractions;
 using FakeItEasy;
-using Microsoft.Extensions.DependencyInjection;
 using UKHO.PeriodicOutputService.Common.Helpers;
 using UKHO.PeriodicOutputService.Common.Models.Fss.Request;
 using UKHO.PeriodicOutputService.Common.Models.Pks;
@@ -327,6 +326,17 @@ namespace UKHO.PeriodicOutputService.Common.UnitTests.Helpers
 
             // Assert
             Assert.That(result, Is.Empty);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Does_FileExists_Return_Correct_Value(bool fileExists)
+        {
+            A.CallTo(() => _fakefileSystem.File.Exists(filePath)).Returns(fileExists);
+
+            var result = _fileSystemHelper.FileExists(filePath);
+
+            Assert.That(result, Is.EqualTo(fileExists));
         }
     }
 

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Helpers/FileSystemHelper.cs
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Helpers/FileSystemHelper.cs
@@ -276,5 +276,7 @@ namespace UKHO.PeriodicOutputService.Common.Helpers
                 _fileSystem.Directory.Delete(folderPath);
             }
         }
+
+        public bool FileExists(string filePath) => _fileSystem.File.Exists(filePath);
     }
 }

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Helpers/IFileSystemHelper.cs
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/Helpers/IFileSystemHelper.cs
@@ -47,5 +47,7 @@ namespace UKHO.PeriodicOutputService.Common.Helpers
         Task CreateXmlFromObject<T>(T obj, string filePath, string fileName);
 
         void CreateTextFile(string filePath, string fileName, string content);
+
+        bool FileExists(string filePath);
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,13 +9,6 @@ parameters:
     displayName: "Disable Stryker"
     type: boolean
     default: false
-  - name: StrykerVersion
-    displayName: "Stryker version"
-    type: string
-    values:
-      - 'latest'
-      - '4.8.1'
-    default: 'latest'
   - name: SnykOnlyFailIfFixable
     displayName: "Snyk - fail only if an issue has an available fix"
     type: boolean
@@ -95,10 +88,7 @@ stages:
             command: custom
             custom: tool
             workingDirectory: $(Agent.TempDirectory)
-            ${{ if eq(parameters.StrykerVersion, 'latest') }}:
-              arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config
-            ${{ else }}:
-              arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config --version ${{ parameters.StrykerVersion }}
+            arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --configfile $(Build.SourcesDirectory)/BuildNuget.config
 
         - task: Powershell@2
           displayName: "Run Stryker"


### PR DESCRIPTION
#### PR Classification
Code cleanup and abstraction improvement for file existence checks, along with test and pipeline updates.

#### PR Summary
This PR introduces an abstracted FileExists method, refactors logging assertions for maintainability, and simplifies Stryker pipeline configuration.
- IFileSystemHelper.cs and FileSystemHelper.cs: Added FileExists method and implementation for file existence checks.
- FileSystemHelperTests.cs: Added unit tests for FileExists.
- FulfilmentDataService.cs: Refactored UpdateSerialAioFile to use FileExists abstraction and updated log message to include year and week number.
- FulfilmentDataServiceTests.cs: Refactored log assertion code with a new CheckLog helper and added log checks for SERIAL.AIO updates.
- azure-pipelines.yml: Removed Stryker version selection and related conditional logic, always installing the latest version.
