### PR TITLE
290760-devops changes for .net 10 upgrade

### DIFF
--- a/Deployment/src/Modules/WebApp/main.tf
+++ b/Deployment/src/Modules/WebApp/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_windows_web_app" "webapp_service" {
   site_config {
     application_stack {    
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -48,7 +48,7 @@ resource "azurerm_windows_web_app_slot" "staging" {
   site_config {
     application_stack {    
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "=1.9.6"
+  required_version = "=1.15.8"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "posterraform.deployment.tfplan"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.54.0"
     }
   }
 
@@ -15,10 +15,12 @@ terraform {
 
 provider "azurerm" {
   features {}
+   version = ">=4.54.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
+  version = ">=4.54.0"
 }

--- a/Deployment/templates/app-deploy.yml
+++ b/Deployment/templates/app-deploy.yml
@@ -158,7 +158,7 @@ jobs:
       displayName: 'Use .NET SDK'
       inputs:
         packageType: sdk
-        version: 8.0.x
+        version: 10.0.x
 
     - task: DotNetCoreCLI@2
       displayName: "Run POS Functional tests"
@@ -234,7 +234,7 @@ jobs:
       displayName: 'Use .NET SDK'
       inputs:
         packageType: sdk
-        version: 8.0.x
+        version: 10.0.x
 
     - task: DotNetCoreCLI@2
       displayName: "Run BESS Functional tests"

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: DotNetVersion
   type: string
-  default: '8.0.x'
+  default: '10.0.x'
 
 jobs:
 - job: UnitTestsAndCodeCoverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ stages:
     dependsOn: []
     variables:
     - name: StrykerDotNetVersion
-      value: 8.0.x
+      value: 10.0.x
     jobs:
     - job: Stryker
       workspace:
@@ -117,7 +117,7 @@ stages:
     jobs:
     - template: Deployment/templates/build-test-publish.yml  
       parameters:
-        DotNetVersion: '8.0.x'
+        DotNetVersion: '10.0.x'
 
   - stage: Devdeploy
     displayName: "Devdeploy (inc terraform, webapp deploy)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ variables:
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.7"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.8"
   - name: WindowsPool1
     value: "NautilusBuild"
   - name: WindowsPool2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,13 +44,13 @@ variables:
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.7"
   - name: WindowsPool1
     value: "NautilusBuild"
   - name: WindowsPool2
     value: "Mare Nubium"
   - name: SdkVersion
-    value: "8.0.x"
+    value: "10.0.x"
   - name: snykAbzuOrganizationId
     value: aeb7543b-8394-457c-8334-a31493d8910d
 


### PR DESCRIPTION
This pull request updates the infrastructure and CI/CD pipeline to support newer versions of key dependencies. The main changes include upgrading the .NET runtime version for the web app and its staging slot, updating the AzureRM Terraform provider to a newer version, and aligning the pipeline with these updates by bumping the container image and SDK versions.

**Dependency and Runtime Upgrades:**

* Updated the `dotnet_version` for both the main web app (`azurerm_windows_web_app.webapp_service`) and its staging slot (`azurerm_windows_web_app_slot.staging`) from `v8.0` to `v10.0` in `main.tf` to use the latest .NET runtime. [[1]](diffhunk://#diff-46be1cae54bed3f7b9f4bc70825a1babffb1f04a7ea5c949a8572a4b30f9a5dcL11-R11) [[2]](diffhunk://#diff-46be1cae54bed3f7b9f4bc70825a1babffb1f04a7ea5c949a8572a4b30f9a5dcL51-R51)
* Increased the required version of the `azurerm` Terraform provider from `=3.116.0` to `>=4.54.0` in `azure.tf` for improved features and compatibility.
* Added the `version = ">=4.54.0"` constraint to both `azurerm` provider blocks in `azure.tf` to ensure consistent provider versions across all resources.

**CI/CD Pipeline Updates:**

* Updated the pipeline container image to `ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.7` and the `SdkVersion` to `10.0.x` in `azure-pipelines.yml` to match the new .NET runtime and tooling requirements.