### PR TITLE
Merge feature/290760/main into main

### DIFF
--- a/Deployment/src/Modules/WebApp/main.tf
+++ b/Deployment/src/Modules/WebApp/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_windows_web_app" "webapp_service" {
   site_config {
     application_stack {    
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -48,7 +48,7 @@ resource "azurerm_windows_web_app_slot" "staging" {
   site_config {
     application_stack {    
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "=1.9.6"
+  required_version = "=1.15.8"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "posterraform.deployment.tfplan"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.54.0"
     }
   }
 
@@ -15,10 +15,12 @@ terraform {
 
 provider "azurerm" {
   features {}
+   version = ">=4.54.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
+  version = ">=4.54.0"
 }

--- a/Deployment/templates/app-deploy.yml
+++ b/Deployment/templates/app-deploy.yml
@@ -158,7 +158,7 @@ jobs:
       displayName: 'Use .NET SDK'
       inputs:
         packageType: sdk
-        version: 8.0.x
+        version: 10.0.x
 
     - task: DotNetCoreCLI@2
       displayName: "Run POS Functional tests"
@@ -234,7 +234,7 @@ jobs:
       displayName: 'Use .NET SDK'
       inputs:
         packageType: sdk
-        version: 8.0.x
+        version: 10.0.x
 
     - task: DotNetCoreCLI@2
       displayName: "Run BESS Functional tests"

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: DotNetVersion
   type: string
-  default: '8.0.x'
+  default: '10.0.x'
 
 jobs:
 - job: UnitTestsAndCodeCoverage

--- a/UKHO.EssFssMock.API/UKHO.EssFssMock.API/UKHO.EssFssMock.API.csproj
+++ b/UKHO.EssFssMock.API/UKHO.EssFssMock.API/UKHO.EssFssMock.API.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -11,11 +11,11 @@
     <NoWarn>1701;1702;8618;8602;8604;8600;8603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.27" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="appsettings.json">

--- a/UKHO.PKSWireMockService.API/UKHO.PKSWireMock.API.csproj
+++ b/UKHO.PKSWireMockService.API/UKHO.PKSWireMock.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -9,13 +9,13 @@
   <ItemGroup>
     <PackageReference Include="JsonConverter.Abstractions" Version="0.13.0" />
     <PackageReference Include="JsonConverter.Newtonsoft.Json" Version="0.13.0" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="8.0.27" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-    <PackageReference Include="WireMock.Net" Version="2.10.0" />
-    <PackageReference Include="WireMock.Net.Abstractions" Version="2.10.0" />
-    <PackageReference Include="WireMock.Org.Abstractions" Version="2.10.0" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="WireMock.Net" Version="2.12.0" />
+    <PackageReference Include="WireMock.Net.Abstractions" Version="2.12.0" />
+    <PackageReference Include="WireMock.Org.Abstractions" Version="2.12.0" />
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests/UKHO.AdmiraltyInformationOverlay.Fulfilment.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,23 +20,23 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>    
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
@@ -7,10 +7,6 @@ using Azure.Security.KeyVault.Secrets;
 using Elastic.Apm.Azure.Storage;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm;
-using Elastic.Apm.Api;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -28,7 +24,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
     [ExcludeFromCodeCoverage]
     public static class Program
     {
-        private static readonly InMemoryChannel s_aIChannel = new();
         private static readonly string s_assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
 
         public static async Task Main()
@@ -56,8 +51,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    s_aIChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -139,12 +132,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
 
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-             (config) =>
-             {
-                 config.TelemetryChannel = s_aIChannel;
-             });
 
             var fssApiConfiguration = new FssApiConfiguration();
 

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
@@ -124,7 +124,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                         config.System = eventHubConfig.System;
                         config.Service = eventHubConfig.Service;
                         config.AdditionalValuesProvider = additionalValues =>
-                        config.AdditionalValuesProvider = additionalValues =>
                         {
                             additionalValues["_AssemblyVersion"] = s_assemblyVersion;
                         };

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/UKHO.AdmiraltyInformationOverlay.Fulfilment.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/UKHO.AdmiraltyInformationOverlay.Fulfilment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -18,19 +18,19 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.34.2" />
-    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.7.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.16" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="Elastic.Apm" Version="1.34.5" />
+    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.7.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
   </ItemGroup>
 

--- a/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/UKHO.BESS.API.FunctionalTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/UKHO.BESS.API.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/UKHO.BESS.API.FunctionalTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.API.FunctionalTests/UKHO.BESS.API.FunctionalTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
@@ -15,10 +15,10 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -26,13 +26,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>  
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/UKHO.BESS.BuilderService.UnitTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService.UnitTests/UKHO.BESS.BuilderService.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -24,22 +24,22 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />    
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/UKHO.BESS.BuilderService.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/UKHO.BESS.BuilderService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -14,21 +14,21 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.34.2" />
-    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.7" />
+    <PackageReference Include="Elastic.Apm" Version="1.34.5" />
+    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.16" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
   </ItemGroup>
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob.UnitTests/UKHO.BESS.CleanUpJob.UnitTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob.UnitTests/UKHO.BESS.CleanUpJob.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,23 +20,23 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
@@ -4,8 +4,6 @@ using System.Reflection;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,7 +21,6 @@ namespace UKHO.BESS.CleanUpJob
     public static class Program
     {
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
-        private static readonly InMemoryChannel aiChannel = new();
 
         private static async Task Main()
         {
@@ -50,8 +47,6 @@ namespace UKHO.BESS.CleanUpJob
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    aiChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -135,13 +130,6 @@ namespace UKHO.BESS.CleanUpJob
                     });
                 }
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-                (config) =>
-                {
-                    config.TelemetryChannel = aiChannel;
-                }
-            );
 
             if (configuration != null)
             {

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/UKHO.BESS.CleanUpJob.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/UKHO.BESS.CleanUpJob.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -14,20 +14,20 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.16" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
   </ItemGroup>
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService.UnitTests/UKHO.BESS.ConfigurationService.UnitTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService.UnitTests/UKHO.BESS.ConfigurationService.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -25,23 +25,23 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
@@ -28,7 +28,6 @@ namespace UKHO.BESS.ConfigurationService
     [ExcludeFromCodeCoverage]
     public static class Program
     {
-        private static readonly InMemoryChannel aiChannel = new();
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
         private const string BESSConfigurationService = "BESSConfigurationService";
 
@@ -58,8 +57,6 @@ namespace UKHO.BESS.ConfigurationService
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    aiChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -139,13 +136,6 @@ namespace UKHO.BESS.ConfigurationService
                     });
                 }
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-                (config) =>
-                {
-                    config.TelemetryChannel = aiChannel;
-                }
-            );
 
             if (configuration != null)
             {

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/UKHO.BESS.ConfigurationService.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/UKHO.BESS.ConfigurationService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -14,24 +14,24 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.34.2" />
-    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.2" />
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.34.5" />
+    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.47" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.47" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.24163.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.16" />
-    <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UKHO.PeriodicOutputService.Common\UKHO.PeriodicOutputService.Common.csproj" />

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.API.FunctionalTests/UKHO.PeriodicOutputService.API.FunctionalTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.API.FunctionalTests/UKHO.PeriodicOutputService.API.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common.UnitTests/UKHO.PeriodicOutputService.Common.UnitTests.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common.UnitTests/UKHO.PeriodicOutputService.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,19 +20,19 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/UKHO.PeriodicOutputService.Common.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/UKHO.PeriodicOutputService.Common.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -19,17 +19,17 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.27.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageReference Include="DiscUtils.Iso9660" Version="0.16.13" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
     <PackageReference Include="UKHO.WeekNumberUtils" Version="1.5.22270.11" />
     <PackageReference Include="UKHO.Torus.Enc.Core" Version="2.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Runtime.Caching" Version="9.0.16" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/UKHO.PeriodicOutputService.Common.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.PeriodicOutputService.Common/UKHO.PeriodicOutputService.Common.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.16" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
-    <PackageReference Include="UKHO.WeekNumberUtils" Version="1.5.25288.2" />
+    <PackageReference Include="UKHO.WeekNumberUtils" Version="1.5.22270.11" />
     <PackageReference Include="UKHO.Torus.Enc.Core" Version="2.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Runtime.Caching" Version="9.0.16" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ stages:
     dependsOn: []
     variables:
     - name: StrykerDotNetVersion
-      value: 8.0.x
+      value: 10.0.x
     jobs:
     - job: Stryker
       workspace:
@@ -117,7 +117,7 @@ stages:
     jobs:
     - template: Deployment/templates/build-test-publish.yml  
       parameters:
-        DotNetVersion: '8.0.x'
+        DotNetVersion: '10.0.x'
 
   - stage: Devdeploy
     displayName: "Devdeploy (inc terraform, webapp deploy)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ variables:
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.7"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.8"
   - name: WindowsPool1
     value: "NautilusBuild"
   - name: WindowsPool2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,13 +44,13 @@ variables:
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.7"
   - name: WindowsPool1
     value: "NautilusBuild"
   - name: WindowsPool2
     value: "Mare Nubium"
   - name: SdkVersion
-    value: "8.0.x"
+    value: "10.0.x"
   - name: snykAbzuOrganizationId
     value: aeb7543b-8394-457c-8334-a31493d8910d
 


### PR DESCRIPTION
This pull request upgrades the solution to .NET 10.0, updates related Azure provider and SDK versions, and refreshes several package dependencies across multiple projects. It also removes some unused Application Insights configuration code and ensures all build and deployment pipelines are aligned with the new .NET version.

**.NET and Azure Provider Upgrades:**

* Updated all project files (`.csproj`) to target `.NET 10.0` instead of `.NET 8.0` to leverage the latest features and improvements. [[1]](diffhunk://#diff-6ead96f498d8f1bb7e941220aa08174bb0eebee24f32455977385cd205fa8ffcL3-R3) [[2]](diffhunk://#diff-c04370fa659b49a36f1df1f99db0713a90b63abae708cc33a6f413c7ce2c94beL4-R18) [[3]](diffhunk://#diff-bb0ae931fca45d4ec58bec64d427902b39c5b4a1d4bb779c293c50e4cbbd7c3eL4-R4) [[4]](diffhunk://#diff-8fac20f902e25cb6980c31ffe85ec75fc222fb08e2c93b7c8662a2c82b178e3dL5-R5) [[5]](diffhunk://#diff-1014e39e83402ad029da71f3225144976422ded0033e111e4580754ba0380f0bL4-R4) [[6]](diffhunk://#diff-48f70efd6fbe820ded5a1cab7f59d8cde8bed56cda78ce997d65adaec6db2502L1-R4) [[7]](diffhunk://#diff-6d7a7843c12fcacf4c8b84b752b3033ade7d3b73a0c387e982ce90b08ba23877L4-R4)
* Updated Azure provider version in Terraform configuration to require `>=4.54.0` and set Terraform CLI version to `1.15.8`. [[1]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL5-R9) [[2]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbR18-R25)

**Build and Deployment Pipeline Updates:**

* Changed all pipeline and deployment YAML files to use `.NET SDK 10.0.x` for builds and tests. [[1]](diffhunk://#diff-8940d5230c0466ac3c94da82f08c66005b31dc66be267f5067ab1e37495554b9L161-R161) [[2]](diffhunk://#diff-8940d5230c0466ac3c94da82f08c66005b31dc66be267f5067ab1e37495554b9L237-R237) [[3]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL4-R4)
* Updated the Azure Web App and slot configurations to use `dotnet_version = "v10.0"`. [[1]](diffhunk://#diff-46be1cae54bed3f7b9f4bc70825a1babffb1f04a7ea5c949a8572a4b30f9a5dcL11-R11) [[2]](diffhunk://#diff-46be1cae54bed3f7b9f4bc70825a1babffb1f04a7ea5c949a8572a4b30f9a5dcL51-R51)

**Dependency and Package Updates:**

* Upgraded various NuGet packages to their latest compatible versions, including `Microsoft.AspNetCore.*`, `Swashbuckle.AspNetCore`, `WireMock.Net`, `Serilog`, `System.IO.Abstractions`, `coverlet`, and others, to ensure compatibility with .NET 10.0 and improve security/stability. [[1]](diffhunk://#diff-6ead96f498d8f1bb7e941220aa08174bb0eebee24f32455977385cd205fa8ffcL14-R18) [[2]](diffhunk://#diff-c04370fa659b49a36f1df1f99db0713a90b63abae708cc33a6f413c7ce2c94beL4-R18) [[3]](diffhunk://#diff-1014e39e83402ad029da71f3225144976422ded0033e111e4580754ba0380f0bL18-R34) [[4]](diffhunk://#diff-bb0ae931fca45d4ec58bec64d427902b39c5b4a1d4bb779c293c50e4cbbd7c3eL23-R39) [[5]](diffhunk://#diff-8fac20f902e25cb6980c31ffe85ec75fc222fb08e2c93b7c8662a2c82b178e3dL21-R33) [[6]](diffhunk://#diff-48f70efd6fbe820ded5a1cab7f59d8cde8bed56cda78ce997d65adaec6db2502L27-R42)

**Codebase Cleanup:**

* Removed unused Application Insights channel configuration and related code from `Program.cs` in `UKHO.AdmiraltyInformationOverlay.Fulfilment`, simplifying telemetry setup. [[1]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaL10-L13) [[2]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaL31) [[3]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaL59-L60) [[4]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaL134) [[5]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaL143-L148)

These changes modernize the codebase, improve maintainability, and ensure compatibility with the latest .NET and Azure features.