### PR TITLE
Update azurerm provider version to 4.81.0

### DIFF
--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=4.54.0"
+      version = "=4.81.0"
     }
   }
 
@@ -15,12 +15,12 @@ terraform {
 
 provider "azurerm" {
   features {}
-   version = ">=4.54.0"
+   version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
-  version = ">=4.54.0"
+  version = "=4.81.0"
 }

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -15,12 +15,10 @@ terraform {
 
 provider "azurerm" {
   features {}
-   version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
-  version = "=4.81.0"
 }


### PR DESCRIPTION
This pull request updates the Azure provider version requirements in the Terraform configuration to ensure consistent and predictable deployments.

Dependency version pinning:

* The `azurerm` provider version is now pinned to exactly `4.81.0` in both the `required_providers` block and all `provider "azurerm"` declarations, replacing the previous minimum version constraint (`>=4.54.0`). This change helps prevent unexpected issues from future provider updates. [[1]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL5-R5) [[2]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL18-R25)