### PR TITLE
fixed appinsights log issue

### DIFF
--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
@@ -7,7 +7,8 @@ using Azure.Security.KeyVault.Secrets;
 using Elastic.Apm.Azure.Storage;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm;
-using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,7 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
     [ExcludeFromCodeCoverage]
     public static class Program
     {
+        private static readonly InMemoryChannel s_aIChannel = new();
         private static readonly string s_assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
 
         public static async Task Main()
@@ -52,9 +54,8 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
                 finally
                 {
-                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
-                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
-                    telemetryClient?.Flush();
+                    //Ensure all buffered app insights logs are flushed into Azure
+                    s_aIChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -135,6 +136,12 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
 
             });
+
+            serviceCollection.Configure<TelemetryConfiguration>(
+             (config) =>
+             {
+                 config.TelemetryChannel = s_aIChannel;
+             });
 
             var fssApiConfiguration = new FssApiConfiguration();
 

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/Program.cs
@@ -7,10 +7,7 @@ using Azure.Security.KeyVault.Secrets;
 using Elastic.Apm.Azure.Storage;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm;
-using Elastic.Apm.Api;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Extensions.Azure;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -28,7 +25,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
     [ExcludeFromCodeCoverage]
     public static class Program
     {
-        private static readonly InMemoryChannel s_aIChannel = new();
         private static readonly string s_assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
 
         public static async Task Main()
@@ -56,8 +52,9 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    s_aIChannel.Flush();
+                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
+                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
+                    telemetryClient?.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -139,12 +136,6 @@ namespace UKHO.AdmiraltyInformationOverlay.Fulfilment
                 }
 
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-             (config) =>
-             {
-                 config.TelemetryChannel = s_aIChannel;
-             });
 
             var fssApiConfiguration = new FssApiConfiguration();
 

--- a/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/UKHO.AdmiraltyInformationOverlay.Fulfilment.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.AdmiraltyInformationOverlay.Fulfilment/UKHO.AdmiraltyInformationOverlay.Fulfilment.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Elastic.Apm" Version="1.34.5" />
     <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.7.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />

--- a/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/UKHO.BESS.BuilderService.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.BuilderService/UKHO.BESS.BuilderService.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Elastic.Apm" Version="1.34.5" />
     <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
@@ -4,7 +4,8 @@ using System.Reflection;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -22,6 +23,7 @@ namespace UKHO.BESS.CleanUpJob
     public static class Program
     {
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
+        private static readonly InMemoryChannel aiChannel = new();
 
         private static async Task Main()
         {
@@ -48,9 +50,8 @@ namespace UKHO.BESS.CleanUpJob
                 }
                 finally
                 {
-                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
-                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
-                    telemetryClient?.Flush();
+                    //Ensure all buffered app insights logs are flushed into Azure
+                    aiChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -94,6 +95,13 @@ namespace UKHO.BESS.CleanUpJob
         private static void ConfigureServices(IServiceCollection serviceCollection, IConfiguration configuration)
         {
             serviceCollection.AddApplicationInsightsTelemetryWorkerService();
+
+            serviceCollection.Configure<TelemetryConfiguration>(
+                (config) =>
+                {
+                    config.TelemetryChannel = aiChannel;
+                }
+            );
 
             //Add logging
             serviceCollection.AddLogging(loggingBuilder =>

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/Program.cs
@@ -4,8 +4,7 @@ using System.Reflection;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,7 +22,6 @@ namespace UKHO.BESS.CleanUpJob
     public static class Program
     {
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
-        private static readonly InMemoryChannel aiChannel = new();
 
         private static async Task Main()
         {
@@ -50,8 +48,9 @@ namespace UKHO.BESS.CleanUpJob
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    aiChannel.Flush();
+                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
+                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
+                    telemetryClient?.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -135,13 +134,6 @@ namespace UKHO.BESS.CleanUpJob
                     });
                 }
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-                (config) =>
-                {
-                    config.TelemetryChannel = aiChannel;
-                }
-            );
 
             if (configuration != null)
             {

--- a/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/UKHO.BESS.CleanUpJob.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.CleanUpJob/UKHO.BESS.CleanUpJob.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
@@ -7,8 +7,7 @@ using Azure.Security.KeyVault.Secrets;
 using Elastic.Apm;
 using Elastic.Apm.Azure.Storage;
 using Elastic.Apm.DiagnosticSource;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -28,7 +27,6 @@ namespace UKHO.BESS.ConfigurationService
     [ExcludeFromCodeCoverage]
     public static class Program
     {
-        private static readonly InMemoryChannel aiChannel = new();
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
         private const string BESSConfigurationService = "BESSConfigurationService";
 
@@ -58,8 +56,9 @@ namespace UKHO.BESS.ConfigurationService
                 }
                 finally
                 {
-                    //Ensure all buffered app insights logs are flushed into Azure
-                    aiChannel.Flush();
+                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
+                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
+                    telemetryClient?.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -139,13 +138,6 @@ namespace UKHO.BESS.ConfigurationService
                     });
                 }
             });
-
-            serviceCollection.Configure<TelemetryConfiguration>(
-                (config) =>
-                {
-                    config.TelemetryChannel = aiChannel;
-                }
-            );
 
             if (configuration != null)
             {

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/Program.cs
@@ -7,7 +7,8 @@ using Azure.Security.KeyVault.Secrets;
 using Elastic.Apm;
 using Elastic.Apm.Azure.Storage;
 using Elastic.Apm.DiagnosticSource;
-using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,7 @@ namespace UKHO.BESS.ConfigurationService
     [ExcludeFromCodeCoverage]
     public static class Program
     {
+        private static readonly InMemoryChannel aiChannel = new();
         private static readonly string assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyFileVersionAttribute>().Single().Version;
         private const string BESSConfigurationService = "BESSConfigurationService";
 
@@ -56,9 +58,8 @@ namespace UKHO.BESS.ConfigurationService
                 }
                 finally
                 {
-                    //Ensure all buffered app insights telemetry is flushed to Azure before the short-lived job exits
-                    var telemetryClient = serviceProvider.GetService<TelemetryClient>();
-                    telemetryClient?.Flush();
+                    //Ensure all buffered app insights logs are flushed into Azure
+                    aiChannel.Flush();
                     await Task.Delay(delayTime);
                 }
             }
@@ -138,6 +139,13 @@ namespace UKHO.BESS.ConfigurationService
                     });
                 }
             });
+
+            serviceCollection.Configure<TelemetryConfiguration>(
+                (config) =>
+                {
+                    config.TelemetryChannel = aiChannel;
+                }
+            );
 
             if (configuration != null)
             {

--- a/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/UKHO.BESS.ConfigurationService.csproj
+++ b/UKHO.PeriodicOutputService/UKHO.BESS.ConfigurationService/UKHO.BESS.ConfigurationService.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Elastic.Apm" Version="1.34.5" />
     <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.5" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="3.1.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.47" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.47" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />


### PR DESCRIPTION
This pull request introduces improvements to how Application Insights telemetry is handled in multiple services, ensuring that all buffered logs are properly flushed before shutdown. Additionally, it standardizes the Application Insights package versions across projects. The most important changes are grouped below.

**Telemetry Handling Improvements:**

* Introduced an `InMemoryChannel` for Application Insights in `Program.cs` files of `UKHO.AdmiraltyInformationOverlay.Fulfilment`, `UKHO.BESS.CleanUpJob`, and `UKHO.BESS.ConfigurationService`, and configured the telemetry channel to ensure all buffered logs are flushed to Azure before application exit. [[1]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaR29) [[2]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaR57-R58) [[3]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaR140-R145) [[4]](diffhunk://#diff-75885fe1d1a708e0bb6e754a24d2eefe462b4b72cba9f2980d29d9ba5b90dee7R26) [[5]](diffhunk://#diff-75885fe1d1a708e0bb6e754a24d2eefe462b4b72cba9f2980d29d9ba5b90dee7R53-R54) [[6]](diffhunk://#diff-75885fe1d1a708e0bb6e754a24d2eefe462b4b72cba9f2980d29d9ba5b90dee7R99-R105) [[7]](diffhunk://#diff-144bc5ab81ac5126fa677440b264410dcd53be06403c91e4bc7254a7e3be8186R31) [[8]](diffhunk://#diff-144bc5ab81ac5126fa677440b264410dcd53be06403c91e4bc7254a7e3be8186R61-R62) [[9]](diffhunk://#diff-144bc5ab81ac5126fa677440b264410dcd53be06403c91e4bc7254a7e3be8186R143-R149)

**Dependency Updates:**

* Downgraded `Microsoft.ApplicationInsights` and `Microsoft.ApplicationInsights.WorkerService` package versions from `3.1.2` to `2.23.0` in all affected `.csproj` files to ensure compatibility with the new telemetry channel usage. [[1]](diffhunk://#diff-8fac20f902e25cb6980c31ffe85ec75fc222fb08e2c93b7c8662a2c82b178e3dL23-R23) [[2]](diffhunk://#diff-6d7a7843c12fcacf4c8b84b752b3033ade7d3b73a0c387e982ce90b08ba23877L19-R19) [[3]](diffhunk://#diff-de0660cad532ca0525d6307dbbeac97fc4366c5088521c8385a9595efd5129faL17-R18) [[4]](diffhunk://#diff-a6ebbd7e24c8cebbc391f969ded25a37885dc8ab5282a6b8b46e22e3d4285dbaL20-R21)

**Codebase Consistency:**

* Updated `using` statements to include necessary Application Insights namespaces for the new telemetry channel implementation. [[1]](diffhunk://#diff-c3a3abd2bd08c8c428b7eb8420befc572341767659fb86001657b3d6b1c59fdaR10-R11) [[2]](diffhunk://#diff-75885fe1d1a708e0bb6e754a24d2eefe462b4b72cba9f2980d29d9ba5b90dee7R7-R8)

These changes collectively improve reliability and consistency in how telemetry data is handled across the services.